### PR TITLE
BE/FE (feat): add validation to time conflict

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -13,9 +13,13 @@ class SectionsController < ApplicationController
   end
 
   def enroll
-    current_student.sections << @section unless current_student.sections.include?(@section)
+    enrollment = current_student.enrollments.build(section: @section)
 
-    redirect_to available_sections_path, notice: { text: "Enrolled in #{@section.subject.name}" }
+    if enrollment.save
+      redirect_to available_sections_path, notice: { text: "Enrolled in #{@section.subject.name}" }
+    else
+      redirect_to available_sections_path, alert: { text: enrollment.errors.full_messages.to_sentence }
+    end
   end
 
   def withdraw

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -3,4 +3,32 @@
 class Enrollment < ApplicationRecord
   belongs_to :student
   belongs_to :section
+
+  validates :student_id, uniqueness: { scope: :section_id }
+  validate :no_time_conflict
+
+  private
+
+  def no_time_conflict
+    return unless student && section
+
+    student_sections = student.sections
+    return if student_sections.empty?
+
+    student_sections.each do |student_section|
+      next unless time_conflict?(section, student_section)
+
+      errors.add(:section, 'conflicts with another section')
+      break
+    end
+  end
+
+  def time_conflict?(section1, section2)
+    days1 = section1.days_of_week_list.split(', ')
+    days2 = section2.days_of_week_list.split(', ')
+    days_overlap = days1.intersect?(days2)
+
+    time_overlap = (section1.start_time <= section2.end_time) && (section2.start_time < section1.end_time)
+    days_overlap && time_overlap
+  end
 end


### PR DESCRIPTION
This pull request introduces changes to the `enroll` method in the `SectionsController` and adds validation logic to the `Enrollment` model to prevent students from enrolling in conflicting sections. The most important changes include updating the enrollment process to handle errors and adding custom validation to check for scheduling conflicts.

### Changes to enrollment process:

* [`app/controllers/sections_controller.rb`](diffhunk://#diff-f466b80869d56070e574e91e0b74489dcf37e652dcb2a8a2603729edf3ec370dL16-R22): Modified the `enroll` method to use `current_student.enrollments.build(section: @section)` and handle potential errors during enrollment. If the enrollment is successful, it redirects with a success notice; otherwise, it redirects with an error alert.

### Validation logic for enrollments:

* [`app/models/enrollment.rb`](diffhunk://#diff-183b3519118b57b2f325816458ded0b6814cd76d31336ebd4a4ec9d67638c766R6-R33): Added a `validates :student_id, uniqueness: { scope: :section_id }` to ensure a student cannot enroll in the same section more than once.
* [`app/models/enrollment.rb`](diffhunk://#diff-183b3519118b57b2f325816458ded0b6814cd76d31336ebd4a4ec9d67638c766R6-R33): Implemented a custom validation method `no_time_conflict` to check for time conflicts with other sections the student is enrolled in. If a conflict is detected, an error is added to the `section` attribute.
* [`app/models/enrollment.rb`](diffhunk://#diff-183b3519118b57b2f325816458ded0b6814cd76d31336ebd4a4ec9d67638c766R6-R33): Added a private helper method `time_conflict?` to determine if two sections have overlapping schedules based on their days of the week and start/end times.